### PR TITLE
New features and agent chat fix

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,0 +1,96 @@
+# Local Debugging Guide
+
+## VS Code Launch Configuration
+
+Add the following to `.vscode/launch.json`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug: Backend",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "backend:dev"],
+      "console": "integratedTerminal",
+      "port": 9229,
+      "skipFiles": ["<node_internals>/**", "node_modules/**"]
+    },
+    {
+      "name": "Debug: Frontend",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3090",
+      "webRoot": "${workspaceFolder}/client"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug: Full Stack",
+      "configurations": ["Debug: Backend", "Debug: Frontend"],
+      "stopAll": true
+    }
+  ]
+}
+```
+
+---
+
+## Full Stack Debugging
+
+### Steps
+
+1. **In a separate terminal**, start the frontend dev server (the only manual step):
+
+   ```bash
+   npm run frontend:dev
+   ```
+
+2. Wait for it to say `ready in...`
+
+3. Set your breakpoints in both backend (`.ts`) and frontend (`.tsx`) files.
+
+4. In VS Code's **Run and Debug** panel, select **Debug: Full Stack** from the dropdown.
+
+5. Press the green play button (**F5**).
+
+### What Happens
+
+- **Debug: Backend** — runs `npm run backend:dev` in a VS Code terminal and automatically attaches the debugger.
+- **Debug: Frontend** — opens a new Chrome window with debugging enabled, navigating to `http://localhost:3090`.
+- Because the frontend server is already running, the page loads correctly.
+- Breakpoints will be hit reliably in both backend and frontend code.
+
+---
+
+## Speeding Up the Build
+
+Avoid `npm run frontend` — it runs 5 builds sequentially every time. Use `npm run build` instead, which runs them in parallel and **caches unchanged packages** via Turborepo.
+
+| Changed | Command |
+|---|---|
+| Only `packages/data-provider` | `npm run build:data-provider` |
+| Only `packages/api` | `cd packages/api && npm run build` |
+| Full rebuild | `npm run build` |
+
+---
+
+## Backend-Only Debugging (Express API)
+
+1. Set the Node memory limit:
+
+   ```bash
+   export NODE_OPTIONS="--max-old-space-size=4096"
+   ```
+
+2. Build the project:
+
+   ```bash
+   npm run build
+   ```
+
+3. In VS Code's **Run and Debug** panel, select **Debug: Backend** and press **F5**.
+
+4. Open your browser and go to `http://localhost:3080`.

--- a/api/server/middleware/buildEndpointOption.js
+++ b/api/server/middleware/buildEndpointOption.js
@@ -48,9 +48,7 @@ async function buildEndpointOption(req, res, next) {
   }
 
   const appConfig = req.config;
-  if (appConfig.modelSpecs?.list && appConfig.modelSpecs?.enforce
-    && !isAgentsEndpoint(endpoint)
-  ) {
+  if (appConfig.modelSpecs?.list && appConfig.modelSpecs?.enforce && !isAgentsEndpoint(endpoint)) {
     /** @type {{ list: TModelSpec[] }}*/
     const { list } = appConfig.modelSpecs;
     const { spec } = parsedBody;

--- a/api/server/middleware/buildEndpointOption.js
+++ b/api/server/middleware/buildEndpointOption.js
@@ -48,7 +48,9 @@ async function buildEndpointOption(req, res, next) {
   }
 
   const appConfig = req.config;
-  if (appConfig.modelSpecs?.list && appConfig.modelSpecs?.enforce) {
+  if (appConfig.modelSpecs?.list && appConfig.modelSpecs?.enforce
+    && !isAgentsEndpoint(endpoint)
+  ) {
     /** @type {{ list: TModelSpec[] }}*/
     const { list } = appConfig.modelSpecs;
     const { spec } = parsedBody;

--- a/client/src/components/Nav/AccountSettings.tsx
+++ b/client/src/components/Nav/AccountSettings.tsx
@@ -50,7 +50,7 @@ function AccountSettings() {
         <div className="text-token-text-secondary ml-3 mr-2 py-2 text-sm" role="note">
           <div>{user?.email ?? localize('com_nav_user')}</div>
           <div>
-            {localize('com_auth_model_token_monthly_spend')}:{' '}
+            {localize('com_auth_model_token_monthly_cost')}:{' '}
             {spendData?.spend != null ? `$${spendData.spend.toFixed(4)}` : '$0.0000'}
           </div>
         </div>

--- a/client/src/components/Nav/SettingsTabs/Account/Account.tsx
+++ b/client/src/components/Nav/SettingsTabs/Account/Account.tsx
@@ -5,9 +5,12 @@ import Avatar from './Avatar';
 import EnableTwoFactorItem from './TwoFactorAuthentication';
 import BackupCodesItem from './BackupCodesItem';
 import { useAuthContext } from '~/hooks';
+import { useGetStartupConfig } from '~/data-provider';
 
 function Account() {
   const { user } = useAuthContext();
+  const { data: startupConfig } = useGetStartupConfig();
+  const deleteAccountEnabled = startupConfig?.interface?.deleteAccount !== false;
 
   return (
     <div className="flex flex-col gap-3 p-1 text-sm text-text-primary">
@@ -30,7 +33,7 @@ function Account() {
         </>
       )}
       <div className="pb-3">
-        <DeleteAccount />
+        <DeleteAccount disabled={!deleteAccountEnabled} />
       </div>
     </div>
   );

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -219,7 +219,7 @@
   "com_auth_model_token_cost": "Model Token Cost",
   "com_auth_model_token_cost_description": "Each model is rated by its token consumption cost. Higher-tier models offer greater reasoning capability but consume more tokens. Please select models appropriate to your task to help manage your monthly max usage ($20). For more information on token costs, please visit this",
   "com_auth_model_token_cost_pricing_list": "pricing list",
-  "com_auth_model_token_monthly_cost": "Current usage this month",
+  "com_auth_model_token_monthly_cost": "Current usage",
   "com_auth_model_token_cost_economy": "Economy",
   "com_auth_model_token_cost_standard": "Standard",
   "com_auth_model_token_cost_premium": "Premium",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -219,7 +219,7 @@
   "com_auth_model_token_cost": "Model Token Cost",
   "com_auth_model_token_cost_description": "Each model is rated by its token consumption cost. Higher-tier models offer greater reasoning capability but consume more tokens. Please select models appropriate to your task to help manage your monthly max usage ($20). For more information on token costs, please visit this",
   "com_auth_model_token_cost_pricing_list": "pricing list",
-  "com_auth_model_token_monthly_spend": "monthly spend",
+  "com_auth_model_token_monthly_cost": "Current usage this month",
   "com_auth_model_token_cost_economy": "Economy",
   "com_auth_model_token_cost_standard": "Standard",
   "com_auth_model_token_cost_premium": "Premium",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -671,6 +671,7 @@ export const interfaceSchema = z
         public: z.boolean().optional(),
       })
       .optional(),
+    deleteAccount: z.boolean().optional(),
   })
   .default({
     endpointsMenu: true,
@@ -718,6 +719,7 @@ export const interfaceSchema = z
       share: false,
       public: false,
     },
+    deleteAccount: true,
   });
 
 export type TInterfaceConfig = z.infer<typeof interfaceSchema>;

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -719,7 +719,7 @@ export const interfaceSchema = z
       share: false,
       public: false,
     },
-    deleteAccount: true,
+    deleteAccount: false,
   });
 
 export type TInterfaceConfig = z.infer<typeof interfaceSchema>;

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -56,6 +56,7 @@ export async function loadDefaultInterface({
     peoplePicker: interfaceConfig?.peoplePicker,
     marketplace: interfaceConfig?.marketplace,
     remoteAgents: interfaceConfig?.remoteAgents,
+    deleteAccount: interfaceConfig?.deleteAccount,
   });
 
   return loadedInterface;

--- a/patched-files.md
+++ b/patched-files.md
@@ -21,8 +21,13 @@
 
 ### Table of prices list and labels in login page
 
-[PR](https://github.com/brown-ccv/LibreChat/pull/17/changes#diff-c0fa59f8385909de9f593c765770ac70cec3d86cbfc11c3e2e4749ecc5c0f476)
+[PR 17](https://github.com/brown-ccv/LibreChat/pull/17/changes#diff-c0fa59f8385909de9f593c765770ac70cec3d86cbfc11c3e2e4749ecc5c0f476)
 
 - client/src/components/Auth/AuthLayout.tsx
 - client/src/components/Nav/AccountSettings.tsx
 - client/src/locales/en/translation.json
+
+[PR 19](https://github.com/brown-ccv/LibreChat/pull/19)
+
+- client/src/components/Nav/SettingsTabs/Account/Account.tsx
+- packages/data-provider/src/config.ts

--- a/patched-files.md
+++ b/patched-files.md
@@ -1,0 +1,28 @@
+
+## Patched Files and Brown specific features
+
+
+### Model Spec, tocken monthly use and litell data-provider
+
+[PR](https://github.com/brown-ccv/LibreChat/commit/f4598c6b164bba23169acd41eb5b5dcca805b9a5)
+
+- api/server/routes/users.js
+- client/src/components/Chat/Landing.tsx
+- client/src/Menus/Endpoints/ModelSelectorContext.tsx
+- client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+- client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+- client/src/data-provider/User/queries.ts
+- client/src/data-provider/index.ts
+- packages/api/src/index.ts
+- packages/api/src/user/litellm.ts
+- packages/data-provider/src/api-endpoints.ts
+- packages/data-provider/src/data-service.ts
+- packages/data-provider/src/keys.ts
+
+### Table of prices list and labels in login page
+
+[PR](https://github.com/brown-ccv/LibreChat/pull/17/changes#diff-c0fa59f8385909de9f593c765770ac70cec3d86cbfc11c3e2e4749ecc5c0f476)
+
+- client/src/components/Auth/AuthLayout.tsx
+- client/src/components/Nav/AccountSettings.tsx
+- client/src/locales/en/translation.json


### PR DESCRIPTION
## fix: agent chats stalling with `modelSpecs.enforce` + configurable delete account

### Summary

Two independent fixes:

1. **Bug fix** — Agent chat requests were being rejected by the backend when `modelSpecs.enforce: true` was set in `librechat.yaml`, causing the chat UI to stall indefinitely.
2. **Feature** — The "Delete Account" button in user settings can now be disabled via `librechat.yaml`.

---

### Fix 1: Agent chat stalling under `modelSpecs.enforce`

**Root cause**

When `modelSpecs.enforce: true` is configured, `buildEndpointOption.js` validates that every chat request includes a `spec` field. Agent requests identify themselves via `agent_id` instead — they never carry a `spec`. The middleware was unconditionally rejecting them with `'No model spec selected'`, which caused the frontend to stall with no visible error.

**Fix**

Skip the enforce check when the endpoint is the agents endpoint:

```js
// api/server/middleware/buildEndpointOption.js
// Before:
if (appConfig.modelSpecs?.list && appConfig.modelSpecs?.enforce) {

// After:
if (appConfig.modelSpecs?.list && appConfig.modelSpecs?.enforce && !isAgentsEndpoint(endpoint)) {