### PR TITLE
feat: added whats new text in auth page

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -82,6 +82,7 @@ function buildSharedPayload() {
     allowAccountDeletion:
       process.env.ALLOW_ACCOUNT_DELETION === undefined ||
       isEnabled(process.env.ALLOW_ACCOUNT_DELETION),
+    appVersion: process.env.APP_VERSION,
   };
 
   const minPasswordLength = parseInt(process.env.MIN_PASSWORD_LENGTH, 10);
@@ -95,6 +96,10 @@ function buildSharedPayload() {
 
   if (typeof process.env.CUSTOM_FOOTER === 'string') {
     payload.customFooter = process.env.CUSTOM_FOOTER;
+  }
+
+  if (typeof process.env.WHATS_NEW_URL === 'string') {
+    payload.whatsNewURL = process.env.WHATS_NEW_URL
   }
 
   return payload;

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -99,7 +99,7 @@ function buildSharedPayload() {
   }
 
   if (typeof process.env.WHATS_NEW_URL === 'string') {
-    payload.whatsNewURL = process.env.WHATS_NEW_URL
+    payload.whatsNewURL = process.env.WHATS_NEW_URL;
   }
 
   return payload;

--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -140,6 +140,21 @@ function AuthLayout({
               <div className="mt-4 border-t border-border-light pt-4 text-center text-xs text-text-secondary">
                 <p>{localize('com_auth_model_maintained_by_ccv')}</p>
               </div>
+                 {startupConfig?.whatsNewURL && (
+                  <div className="mt-4 border-t border-light pt-4 text-left text-xs text-text-secondary">
+                      <p>
+                       {localize('com_auth_model_version_whats_new', { 0: startupConfig?.appVersion ?? ' ' })}{' '}
+                      <a
+                        href={startupConfig.whatsNewURL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-medium text-green-600 underline hover:text-green-700 dark:text-green-500 dark:hover:text-green-400"
+                      >
+                        {localize('com_auth_model_ccv_link')}
+                      </a>
+                      </p>
+                   </div>
+                  )} 
             </div>
           </div>
         </div>

--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -140,21 +140,23 @@ function AuthLayout({
               <div className="mt-4 border-t border-border-light pt-4 text-center text-xs text-text-secondary">
                 <p>{localize('com_auth_model_maintained_by_ccv')}</p>
               </div>
-                 {startupConfig?.whatsNewURL && (
-                  <div className="mt-4 border-t border-light pt-4 text-left text-xs text-text-secondary">
-                      <p>
-                       {localize('com_auth_model_version_whats_new', { 0: startupConfig?.appVersion ?? ' ' })}{' '}
-                      <a
-                        href={startupConfig.whatsNewURL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="font-medium text-green-600 underline hover:text-green-700 dark:text-green-500 dark:hover:text-green-400"
-                      >
-                        {localize('com_auth_model_ccv_link')}
-                      </a>
-                      </p>
-                   </div>
-                  )} 
+              {startupConfig?.whatsNewURL && (
+                <div className="border-light mt-4 border-t pt-4 text-left text-xs text-text-secondary">
+                  <p>
+                    {localize('com_auth_model_version_whats_new', {
+                      0: startupConfig?.appVersion ?? ' ',
+                    })}{' '}
+                    <a
+                      href={startupConfig.whatsNewURL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium text-green-600 underline hover:text-green-700 dark:text-green-500 dark:hover:text-green-400"
+                    >
+                      {localize('com_auth_model_ccv_link')}
+                    </a>
+                  </p>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -224,6 +224,8 @@
   "com_auth_model_token_cost_standard": "Standard",
   "com_auth_model_token_cost_premium": "Premium",
   "com_auth_model_maintained_by_ccv": "This service is maintained by Brown University OIT-CCV.",
+  "com_auth_model_version_whats_new": "Librechat version {{0}} is now available! Check out what's new in this release",
+  "com_auth_model_ccv_link": "Learn more",
   "com_click_to_download": "(click here to download)",
   "com_download_expired": "(download expired)",
   "com_download_expires": "(click here to download - expires {{0}})",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -886,6 +886,8 @@ export type TStartupConfig = {
   >;
   mcpPlaceholder?: string;
   conversationImportMaxFileSize?: number;
+  whatsNewURL?: string;
+  appVersion?: string;
 };
 
 export enum OCRStrategy {


### PR DESCRIPTION
## Add CCV branding and dynamic "What's New" link to Auth page

### Changes

- **`packages/data-provider/src/config.ts`** — Added `whatsNewURL?: string` and `appVersion?: string` to `TStartupConfig`
- **`api/server/routes/config.js`** — Serve `WHATS_NEW_URL` and `APP_VERSION` env vars in the startup config payload; fixed typo causing `whatsNewURL` to be set incorrectly
- **`client/src/components/Auth/AuthLayout.tsx`** — Added "maintained by CCV" message and a conditional "What's New" section with an inline "Learn more" link driven by `startupConfig.whatsNewURL`; version number interpolated from `startupConfig.appVersion`
- **`client/src/locales/en/translation.json`** — Added translation keys: `com_auth_model_maintained_by_ccv`, `com_auth_model_version_whats_new`, `com_auth_model_ccv_link`

### New env vars

| Variable | Description |
|---|---|
| `WHATS_NEW_URL` | URL for the "Learn more" link on the login page |
| `APP_VERSION` | Version string interpolated into the "What's New" message |